### PR TITLE
Detect presence of DLight during initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,23 @@
 
 M5Stack-**Unit & Hat DLight** driver library, based on BH1750FVI sensor to achieve ambient light detection.
 
+## Initialization
+
+`begin()` now returns a `bool` that indicates whether the device acknowledged the `POWER_ON` command on the configured I2C address.
+
+- `true`: a device acknowledged at the configured address, which is treated as sensor present
+- `false`: no device acknowledged at the configured address
+
+Existing code that ignores the return value will continue to work.
+
+```cpp
+M5_DLight sensor;
+
+if (sensor.begin()) {
+	uint16_t lux = sensor.getLUX();
+}
+```
+
 ## Related Link
 
 [Document & Datasheet - M5Unit-DLight](https://docs.m5stack.com/en/unit/dlight)

--- a/examples/Hat_DLight_M5StickC/Hat_DLight_M5StickC.ino
+++ b/examples/Hat_DLight_M5StickC/Hat_DLight_M5StickC.ino
@@ -7,7 +7,7 @@
 * 获取更多资料请访问: http://docs.m5stack.com/zh_CN/hat/hat_dlight
 *
 * Product: Hat DLight.
-* Date: 2023/05/29
+* Date: 2026/04/21
 *******************************************************************************
   Measure and output light intensity on screen and serial port
   测量并在屏幕和串口输出光照强度
@@ -21,6 +21,7 @@ M5GFX display;
 M5Canvas canvas(&display);
 
 M5_DLight sensor;
+bool sensorPresent = false;
 uint16_t lux;
 
 void setup() {
@@ -34,7 +35,15 @@ void setup() {
     canvas.createSprite(display.width(), display.height());
     canvas.setPaletteColor(1, ORANGE);
     Serial.println("Sensor begin.....");
-    sensor.begin(&Wire, 0, 26);  // HAT DLight
+    sensorPresent = sensor.begin(&Wire, 0, 26);  // HAT DLight
+
+    if (!sensorPresent) {
+      Serial.println("Sensor not found");
+      canvas.fillSprite(BLACK);
+      canvas.drawString("Sensor not found", 80, 40);
+      canvas.pushSprite(0, 0);
+      return;
+    }
 
     // CONTINUOUSLY_H_RESOLUTION_MODE
     // CONTINUOUSLY_H_RESOLUTION_MODE2
@@ -48,6 +57,11 @@ void setup() {
 char info[40];
 
 void loop() {
+  if (!sensorPresent) {
+    delay(100);
+    return;
+  }
+
     lux = sensor.getLUX();
     sprintf(info, "lux: %d", lux);
     canvas.fillSprite(BLACK);

--- a/examples/Hat_DLight_M5StickCPlus/Hat_DLight_M5StickCPlus.ino
+++ b/examples/Hat_DLight_M5StickCPlus/Hat_DLight_M5StickCPlus.ino
@@ -7,7 +7,7 @@
 * 获取更多资料请访问: http://docs.m5stack.com/zh_CN/hat/hat_dlight
 *
 * Product: Hat DLight.
-* Date: 2022/07/27
+* Date: 2026/04/21
 *******************************************************************************
   Measure and output light intensity on screen and serial port
   测量并在屏幕和串口输出光照强度
@@ -21,6 +21,7 @@ M5GFX display;
 M5Canvas canvas(&display);
 
 M5_DLight sensor;
+bool sensorPresent = false;
 uint16_t lux;
 
 void setup() {
@@ -34,7 +35,15 @@ void setup() {
     canvas.createSprite(display.width(), display.height());
     canvas.setPaletteColor(1, ORANGE);
     Serial.println("Sensor begin.....");
-    sensor.begin(&Wire, 0, 26);  // HAT DLight
+    sensorPresent = sensor.begin(&Wire, 0, 26);  // HAT DLight
+
+    if (!sensorPresent) {
+      Serial.println("Sensor not found");
+      canvas.fillSprite(BLACK);
+      canvas.drawString("Sensor not found", 60, 60);
+      canvas.pushSprite(0, 0);
+      return;
+    }
 
     // CONTINUOUSLY_H_RESOLUTION_MODE
     // CONTINUOUSLY_H_RESOLUTION_MODE2
@@ -48,6 +57,11 @@ void setup() {
 char info[40];
 
 void loop() {
+  if (!sensorPresent) {
+    delay(100);
+    return;
+  }
+
     lux = sensor.getLUX();
     sprintf(info, "lux: %d", lux);
     canvas.fillSprite(BLACK);

--- a/examples/Unit_DLight_M5Atom/Unit_DLight_M5Atom.ino
+++ b/examples/Unit_DLight_M5Atom/Unit_DLight_M5Atom.ino
@@ -7,7 +7,7 @@
 * 获取更多资料请访问: https://docs.m5stack.com/zh_CN/unit/dlight
 *
 * Product: Unit DLight
-* Date: 2023/05/29
+* Date: 2026/04/21
 *******************************************************************************
   Please connect the sensor to port, the Lux value will be output
   on the serial after successful initialization
@@ -18,12 +18,19 @@
 #include <M5_DLight.h>
 
 M5_DLight sensor;
+bool sensorPresent = false;
 uint16_t lux;
 
 void setup() {
     M5.begin(true, true, true);
     Serial.println("Sensor begin.....");
-    sensor.begin();
+  sensorPresent = sensor.begin();
+
+  if (!sensorPresent) {
+    Serial.println("Sensor not found");
+    M5.dis.fillpix(0xff0000);
+    return;
+  }
 
     // CONTINUOUSLY_H_RESOLUTION_MODE
     // CONTINUOUSLY_H_RESOLUTION_MODE2
@@ -35,6 +42,11 @@ void setup() {
 }
 
 void loop() {
+  if (!sensorPresent) {
+    delay(200);
+    return;
+  }
+
     M5.dis.fillpix(0x00ff00);
     lux = sensor.getLUX();
     Serial.printf("lux: %d\n", lux);

--- a/examples/Unit_DLight_M5Core/Unit_DLight_M5Core.ino
+++ b/examples/Unit_DLight_M5Core/Unit_DLight_M5Core.ino
@@ -7,7 +7,7 @@
 * 获取更多资料请访问: https://docs.m5stack.com/zh_CN/unit/dlight
 *
 * Describe: Unit DLight
-* Date: 2023/5/29
+* Date: 2026/04/21
 *******************************************************************************
   Please connect the sensor to port A (22, 21), the Lux value will be displayed
   on the display after successful initialization
@@ -22,6 +22,7 @@ M5GFX display;
 M5Canvas canvas(&display);
 
 M5_DLight sensor;
+bool sensorPresent = false;
 uint16_t lux;
 
 void setup() {
@@ -34,7 +35,15 @@ void setup() {
     canvas.createSprite(display.width(), display.height());
     canvas.setPaletteColor(1, ORANGE);
     Serial.println("Sensor begin.....");
-    sensor.begin();
+    sensorPresent = sensor.begin();
+
+    if (!sensorPresent) {
+      Serial.println("Sensor not found");
+      canvas.fillSprite(BLACK);
+      canvas.drawString("Sensor not found", 160, 120);
+      canvas.pushSprite(0, 0);
+      return;
+    }
 
     // CONTINUOUSLY_H_RESOLUTION_MODE
     // CONTINUOUSLY_H_RESOLUTION_MODE2
@@ -48,6 +57,11 @@ void setup() {
 char info[40];
 
 void loop() {
+  if (!sensorPresent) {
+    delay(100);
+    return;
+  }
+
     lux = sensor.getLUX();
     sprintf(info, "lux: %d", lux);
     canvas.fillSprite(BLACK);

--- a/examples/Unit_DLight_M5Core2/Unit_DLight_M5Core2.ino
+++ b/examples/Unit_DLight_M5Core2/Unit_DLight_M5Core2.ino
@@ -7,7 +7,7 @@
 * 获取更多资料请访问: https://docs.m5stack.com/zh_CN/unit/dlight
 *
 * Product: Unit DLight
-* Date: 2022/7/27
+* Date: 2026/04/21
 *******************************************************************************
   Please connect the sensor to port A (32,33), the Lux value will be displayed
   on the display after successful initialization 请将传感器连接至端口A(32,33),
@@ -22,6 +22,7 @@ M5GFX display;
 M5Canvas canvas(&display);
 
 M5_DLight sensor;
+bool sensorPresent = false;
 uint16_t lux;
 
 void setup() {
@@ -34,7 +35,15 @@ void setup() {
     canvas.createSprite(display.width(), display.height());
     canvas.setPaletteColor(1, ORANGE);
     Serial.println("Sensor begin.....");
-    sensor.begin();
+    sensorPresent = sensor.begin();
+
+    if (!sensorPresent) {
+      Serial.println("Sensor not found");
+      canvas.fillSprite(BLACK);
+      canvas.drawString("Sensor not found", 160, 120);
+      canvas.pushSprite(0, 0);
+      return;
+    }
 
     // CONTINUOUSLY_H_RESOLUTION_MODE
     // CONTINUOUSLY_H_RESOLUTION_MODE2
@@ -48,6 +57,11 @@ void setup() {
 char info[40];
 
 void loop() {
+  if (!sensorPresent) {
+    delay(100);
+    return;
+  }
+
     lux = sensor.getLUX();
     sprintf(info, "lux: %d", lux);
     canvas.fillSprite(BLACK);

--- a/examples/Unit_DLight_M5StickC/Unit_DLight_M5StickC.ino
+++ b/examples/Unit_DLight_M5StickC/Unit_DLight_M5StickC.ino
@@ -7,7 +7,7 @@
 * 获取更多资料请访问: https://docs.m5stack.com/zh_CN/unit/dlight
 *
 * Product: Unit DLight
-* Date: 2022/7/27
+* Date: 2026/04/21
 *******************************************************************************
   Please connect the sensor to port, the Lux value will be displayed
   on the display after successful initialization 请将传感器连接至端口,
@@ -22,6 +22,7 @@ M5GFX display;
 M5Canvas canvas(&display);
 
 M5_DLight sensor;
+bool sensorPresent = false;
 uint16_t lux;
 
 void setup() {
@@ -35,7 +36,15 @@ void setup() {
     canvas.createSprite(display.width(), display.height());
     canvas.setPaletteColor(1, ORANGE);
     Serial.println("Sensor begin.....");
-    sensor.begin();
+    sensorPresent = sensor.begin();
+
+    if (!sensorPresent) {
+      Serial.println("Sensor not found");
+      canvas.fillSprite(BLACK);
+      canvas.drawString("Sensor not found", 80, 40);
+      canvas.pushSprite(0, 0);
+      return;
+    }
 
     // CONTINUOUSLY_H_RESOLUTION_MODE
     // CONTINUOUSLY_H_RESOLUTION_MODE2
@@ -49,6 +58,11 @@ void setup() {
 char info[40];
 
 void loop() {
+  if (!sensorPresent) {
+    delay(100);
+    return;
+  }
+
     lux = sensor.getLUX();
     sprintf(info, "lux: %d", lux);
     canvas.fillSprite(BLACK);

--- a/examples/Unit_DLight_M5StickCPlus/Unit_DLight_M5StickCPlus.ino
+++ b/examples/Unit_DLight_M5StickCPlus/Unit_DLight_M5StickCPlus.ino
@@ -7,7 +7,7 @@
 * 获取更多资料请访问: https://docs.m5stack.com/zh_CN/unit/dlight
 *
 * Product: Unit DLight
-* Date: 2022/7/27
+* Date: 2026/04/21
 *******************************************************************************
   Please connect the sensor to port, the Lux value will be displayed
   on the display after successful initialization 请将传感器连接至端口,
@@ -22,6 +22,7 @@ M5GFX display;
 M5Canvas canvas(&display);
 
 M5_DLight sensor;
+bool sensorPresent = false;
 uint16_t lux;
 
 void setup() {
@@ -35,7 +36,15 @@ void setup() {
     canvas.createSprite(display.width(), display.height());
     canvas.setPaletteColor(1, ORANGE);
     Serial.println("Sensor begin.....");
-    sensor.begin();
+    sensorPresent = sensor.begin();
+
+    if (!sensorPresent) {
+      Serial.println("Sensor not found");
+      canvas.fillSprite(BLACK);
+      canvas.drawString("Sensor not found", 80, 60);
+      canvas.pushSprite(0, 0);
+      return;
+    }
 
     // CONTINUOUSLY_H_RESOLUTION_MODE
     // CONTINUOUSLY_H_RESOLUTION_MODE2
@@ -49,6 +58,11 @@ void setup() {
 char info[40];
 
 void loop() {
+  if (!sensorPresent) {
+    delay(100);
+    return;
+  }
+
     lux = sensor.getLUX();
     sprintf(info, "lux: %d", lux);
     canvas.fillSprite(BLACK);

--- a/library.json
+++ b/library.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "https://github.com/m5stack/M5-DLight.git"
   },
-  "version": "0.0.5",
+  "version": "0.0.6",
   "frameworks": "arduino",
   "platforms": "espressif32"
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=M5-DLight
-version=0.0.5
+version=0.0.6
 author=M5Stack
 maintainer=M5Stack
 sentence=Library for M5Stack Unit & HAT DLight

--- a/src/M5_DLight.cpp
+++ b/src/M5_DLight.cpp
@@ -6,22 +6,22 @@ M5_DLight::M5_DLight(uint8_t addr)
 }
 
 /*! @brief Initialize the EXTIO2.*/
-void M5_DLight::begin(TwoWire *wire, uint8_t sda, uint8_t scl, uint32_t freq)
+bool M5_DLight::begin(TwoWire *wire, uint8_t sda, uint8_t scl, uint32_t freq)
 {
     _wire = wire;
     _sda  = sda;
     _scl  = scl;
     _freq = freq;
     _wire->begin((int)_sda, (int)_scl, _freq);
-    powerOn();
+    return powerOn();
 }
 
 /*! @brief Write data to the register address. */
-void M5_DLight::writeByte(byte cmd)
+bool M5_DLight::writeByte(byte cmd)
 {
     _wire->beginTransmission(_addr);
     _wire->write(cmd);
-    _wire->endTransmission();
+    return _wire->endTransmission() == 0;
 }
 
 /*! @brief Write the specified length of data to the register.*/
@@ -53,9 +53,9 @@ uint16_t M5_DLight::getLUX()
 }
 
 /*! @brief Turn on the power.*/
-void M5_DLight::powerOn()
+bool M5_DLight::powerOn()
 {
-    writeByte(POWER_ON);
+    return writeByte(POWER_ON);
 }
 
 /*! @brief Turn off the power.*/

--- a/src/M5_DLight.h
+++ b/src/M5_DLight.h
@@ -34,15 +34,15 @@ private:
     uint8_t _scl;
     uint32_t _freq;
     uint8_t _addr;
-    void writeByte(byte cmd);
+    bool writeByte(byte cmd);
     void writeBytes(uint8_t *buffer, size_t size);
     void readBytes(uint8_t *buffer, size_t size);
 
 public:
     M5_DLight(uint8_t addr = 0x23);
-    void begin(TwoWire *wire = &Wire, uint8_t sda = SDA, uint8_t scl = SCL, uint32_t freq = 400000UL);
+    bool begin(TwoWire *wire = &Wire, uint8_t sda = SDA, uint8_t scl = SCL, uint32_t freq = 400000UL);
 
-    void powerOn();
+    bool powerOn();
     void powerOff();
     void setMode(byte mode);
     uint16_t getLUX();


### PR DESCRIPTION
Addressing [Issue 7](https://github.com/m5stack/M5-DLight/issues/7):

1. begin()` now returns a `bool` that indicates whether the device acknowledged the `POWER_ON` command on the configured I2C address.
- `true`: a device acknowledged at the configured address, which is treated as sensor present.
- `false`: no device acknowledged at the configured address.
2. Examples and documentation updated.
3. Code has been tested on ESP32S3 and ESP32-WROOM boards.

> [!IMPORTANT]  
> I do not have the M5Stack hardware needed to test and validate the updated examples.  If someone with the hardware could kindly test and ensure they function properly prior to merging, I would appreciate it.
